### PR TITLE
frontend/serviceWorker: Add custom overwrites for workbox

### DIFF
--- a/liqd_lunch/frontend/package.json
+++ b/liqd_lunch/frontend/package.json
@@ -8,14 +8,16 @@
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
     "bootstrap": "^4.5.0",
+    "cra-append-sw": "^2.7.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.1"
+    "react-scripts": "^3.4.1",
+    "serve": "^11.3.2"
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && cra-append-sw ./src/customSw.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/liqd_lunch/frontend/src/customSw.js
+++ b/liqd_lunch/frontend/src/customSw.js
@@ -1,0 +1,8 @@
+import {registerRoute} from 'workbox-routing';
+import {CacheFirst} from 'workbox-strategies';
+
+registerRoute(
+  ({url}) => url.pathname.startsWith('/api/'),
+  new CacheFirst()
+);
+


### PR DESCRIPTION
This allows us to easily add overwrites for specific requests, using pre-
defined cache strategies.
See: https://developers.google.com/web/tools/workbox/modules/workbox-strategies